### PR TITLE
Fix buttons

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -327,22 +327,11 @@ a:hover {
   display: inline-block; /* needed for anchors */
   position: relative;
 }
-.pop-button:hover {
-  -webkit-transform: translate(-4px, -4px);
-      -ms-transform: translate(-4px, -4px);
-          transform: translate(-4px, -4px);
-}
-/* same as above */
-.pop-button:focus {
-  -webkit-transform: translate(-4px, -4px);
-      -ms-transform: translate(-4px, -4px);
-          transform: translate(-4px, -4px);
-}
 
 .pop-button:active {
-  -webkit-transform: translate(-2px, -2px);
-      -ms-transform: translate(-2px, -2px);
-          transform: translate(-2px, -2px);
+  -webkit-transform: translate(+4px, +4px);
+      -ms-transform: translate(+4px, +4px);
+          transform: translate(+4px, +4px);
 }
 
 @media only screen and (max-width: 500px) {
@@ -372,7 +361,7 @@ a:hover {
 }
 
 /* center social and other links for ipad view */
-@media only screen and (max-width: 767px){ 
+@media only screen and (max-width: 767px){
 
   /* helper class, use to tag things that should be desktop-only */
   .desktop-only{

--- a/public/js/scripts.js
+++ b/public/js/scripts.js
@@ -4,7 +4,7 @@ function injectStyles(rule) {
   var div = $("<div />", {
     html: '&shy;<style>' + rule + '</style>'
   }).appendTo("body");
-}    
+}
 
 // given the time of day, returns a random color scheme
 // matching it.
@@ -65,18 +65,17 @@ function getColorSchemeFromTime() {
 }
 
 function setButtons(darkColor, mediumColor, lightColor, midnight) {
-  
-  //change colors of left and right buttons 
+
+  //change colors of left and right buttons
   injectStyles('.slick-prev:before {color: ' + lightColor + ' !important;');
   injectStyles('.slick-next:before {color: ' + lightColor + ' !important;');
-  
+
   //the show titles at the footer of /blurbs
   $(".pop-button").css('background-color', lightColor);
   $("#allShows a").css('color', lightColor);
   $("#showOftheMonth").css('color', 'black');
 
-
-  var boxShadowHoverCss = "1px 0px " + mediumColor +
+  var boxShadowCss = "1px 0px " + mediumColor +
     ", 0px 1px " + darkColor +
     ", 2px 1px " + mediumColor +
     ", 1px 2px " + darkColor +
@@ -84,45 +83,21 @@ function setButtons(darkColor, mediumColor, lightColor, midnight) {
     ", 2px 3px " + darkColor +
     ", 4px 3px " + mediumColor +
     ", 3px 4px " + darkColor;
-  //console.log(boxShadowHoverCss);
+  //console.log(boxShadowCss);
 
-  var boxShadowActiveCss = "1px 0px " + mediumColor +
-    ", 0px 1px " + darkColor +
-    ", 2px 1px " + mediumColor +
-    ", 1px 2px " + darkColor;
-  //console.log(boxShadowActiveCss);
-
-
-  $(".pop-button").hover(
-      function() {
-        $(this).css('box-shadow', boxShadowHoverCss);
-      },
-      function() {
-        $(this).css('box-shadow', '');
-      }
-      );
-  $(".pop-button").focus(
-      function() {
-        $(this).css('box-shadow', boxShadowHoverCss);
-      },
-      function() {
-        $(this).css('box-shadow', '');
-      }
-      );
-
-  // activated by mousedown
+  $(".pop-button").css('box-shadow', boxShadowCss);
   $(".pop-button").mousedown(
-      function() {
-        $(this).css('box-shadow', boxShadowActiveCss);
-      }
-      );
+    function() {
+      $(this).css('box-shadow', '');
+      return false;
+    }
+  );
 
-  // on mouse up, want to transition to the "hover" state
-  $(".pop-button").mouseup(
-      function() {
-        $(this).css('box-shadow', boxShadowHoverCss);
-      }
-      );
+  $(document).mouseup(
+    function() {
+      $(".pop-button").css('box-shadow', boxShadowCss);
+    }
+  );
 }
 
 function setPageTheme(colorScheme) {
@@ -196,6 +171,7 @@ $(document).ready(function() {
     }
 
     $("#play-icon").toggleClass("fa fa-play fa fa-pause");
+    return false;
   });
 
   // Generate that background image!


### PR DESCRIPTION
I made it so that box shadows are always there, and clicking means pushing down on the button, because that made more sense to me.

The even better way to do it is to half the box shadow and translate the button halfway into the box shadow so that it looks like the button does not bottom out (example: http://jeffreywang.me/newhotness/ ignore the other contents of that page), but I didn't feel like calculating the box shadow pixels, and I'm not sure if you want that.

I also fixed the issue where clicking the play button scrolls to the top of the page. It needed a `return false;` at the end of the click even handler.

There is one case I didn't account for, and that's when you try to hold down the click, and then right click somewhere else.

Checkout this branch and test it because my measurements may be off.

Fixes https://github.com/uclaradio/uclaradio/issues/11 and https://github.com/uclaradio/uclaradio/issues/9

@MatteoVH 