### PR TITLE
Add support for nodemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ How to run locally:
 * Ensure you have Mongo installed and a Mongo db instance is running
   * Mac: run `setup.sh` on your Mac with [homebrew](http://brew.sh/) installed to set up node and MongoDB automatically
 * In the project root directory, run `npm install` to install dependencies (may need sudo)
-* Run `node bin/www` to start the server for development
+* Run `npm start` to start the server for development
 * Point your browser to `http://localhost:3000/` :heart_eyes:
-  
+
 To run on the server:
 * Make sure all packages are installed with `npm install`
 * Run `node bin/www prod` to start the server for production (will require HTTPS and listen on port 80)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "nodemon ./bin/www"
   },
   "dependencies": {
     "async": "^2.1.2",

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@
 # needs to have homebrew installed already
 
 echo 'Setting up UCLARadio repository...'
-echo 'installing macOS packages'
+echo 'Installing macOS packages...'
 brew update
 brew install node
 brew install mongodb
@@ -14,16 +14,17 @@ sudo mkdir -p /data/db
 # privileges for mongodb
 sudo chown -R $USER /data/db
 
-echo 'installing npm packages'
+echo 'Installing npm packages...'
 ## note: might need to update if 'node-gyp rebuild' fails
 # npm explore npm -g -- npm install node-gyp@latest
 ## might have to install cairo for dependent npm packages
 # brew install cairo
 sudo npm install
+npm install -g nodemon
 
 cp defaultPasswords.json passwords.json
 
-echo 'seeding database'
+echo 'Seeding database...'
 node database/scripts/setupPanel.js
 
 echo 'Finished.'


### PR DESCRIPTION
I like using [nodemon](https://nodemon.io), and it seems like a lot of other people in radio do too. Why not make it available for everyone?

Changes are to package.json, the readme, and the setup script.