### PR TITLE
Make Promo Banner a Carousel

### DIFF
--- a/react/frontpage/Frontpage.jsx
+++ b/react/frontpage/Frontpage.jsx
@@ -22,6 +22,8 @@ import WaterFallContent from './components/WaterFallContent.jsx';
 import Error404Page from './components/Error404Page.jsx';
 import StreamIssuesPage from './components/StreamIssuesPage.jsx';
 import AboutPage from './components/AboutPage.jsx';
+import PromoBanner from './components/PromoBanner.jsx';
+
 // Common Components
 import RectImage from '../common/RectImage.jsx';
 
@@ -84,13 +86,7 @@ const FrontpageContent = React.createClass({
 
               <Col xs={12} md={9} className="frontpageCol">
                 { /* Show of the Month */ }
-                <div className="promoBanner">
-                  <Link to="/shows/90">
-                    <RectImage src="/img/sotm-mar17-nuindigo.png" aspectRatio={5}>
-                      <div className="overlay" />
-                    </RectImage>
-                  </Link>
-                </div>
+                <PromoBanner />
                 <FrontPageNavbar />
                 { this.props.children }
               </Col>

--- a/react/frontpage/components/PromoBanner.jsx
+++ b/react/frontpage/components/PromoBanner.jsx
@@ -43,7 +43,6 @@ var PromoBanner = React.createClass({
       ); 
     });
 
-    console.log(banners);
     return (
       <div className="promoBanner">
         <Slider {...settings}>

--- a/react/frontpage/components/PromoBanner.jsx
+++ b/react/frontpage/components/PromoBanner.jsx
@@ -1,0 +1,54 @@
+// PromoBanner.jsx
+// A carousel of various promotion related material (ie Show of the Month, Ticket Giveaways, ect)
+
+import React from 'react';
+
+// Open-Source Components
+import Slider from 'react-slick';
+
+// Common Components
+import RectImage from '../../common/RectImage.jsx';
+
+import  { Link } from 'react-router';
+
+// styling
+require('./PromoBanner.scss');
+
+var PromoBanner = React.createClass({
+  render: function() {
+    var settings = {
+      dots: true,
+      autoplay: true,
+      infinite: true, 
+      fade: true, 
+      autoplaySpeed: 5000
+    };
+
+    return (
+      <div className="promoBanner">
+        <Slider {...settings}>
+          <div>
+            <Link to="/shows/90">
+              <RectImage src="/img/sotm-mar17-nuindigo.png" aspectRatio={5}><div className="overlay" /></RectImage>
+            </Link>
+          </div>
+
+          <div>
+            <Link to="/shows/90">
+              <RectImage src="/img/sotm-feb2017.jpg" aspectRatio={5}><div className="overlay" /></RectImage>
+            </Link>
+          </div>
+
+          <div>
+            <Link to="/shows/90">
+              <RectImage src="/img/sotm_january_2017.png" aspectRatio={5}><div className="overlay" /></RectImage>
+            </Link>
+          </div>
+
+        </Slider>
+      </div>
+    );
+  }
+});
+
+export default PromoBanner;

--- a/react/frontpage/components/PromoBanner.jsx
+++ b/react/frontpage/components/PromoBanner.jsx
@@ -14,6 +14,13 @@ import  { Link } from 'react-router';
 // styling
 require('./PromoBanner.scss');
 
+// Promo Banner Data 
+const bannerData = [
+  {"img": "/img/sotm-mar17-nuindigo.png", "link": "/shows/90"},
+  {"img": "/img/sotm-feb2017.jpg", "link": "/shows/75"},
+  {"img": "/img/sotm_january_2017.png", "link": "/shows/83"}
+];
+
 var PromoBanner = React.createClass({
   render: function() {
     var settings = {
@@ -24,27 +31,23 @@ var PromoBanner = React.createClass({
       autoplaySpeed: 5000
     };
 
+    var banners = bannerData.map(function(banner) {
+      return (
+        <div>
+          <Link to={banner.link}>
+            <RectImage src={banner.img} aspectRatio={5}>
+              <div className="overlay" />
+            </RectImage>
+          </Link>
+        </div>
+      ); 
+    });
+
+    console.log(banners);
     return (
       <div className="promoBanner">
         <Slider {...settings}>
-          <div>
-            <Link to="/shows/90">
-              <RectImage src="/img/sotm-mar17-nuindigo.png" aspectRatio={5}><div className="overlay" /></RectImage>
-            </Link>
-          </div>
-
-          <div>
-            <Link to="/shows/90">
-              <RectImage src="/img/sotm-feb2017.jpg" aspectRatio={5}><div className="overlay" /></RectImage>
-            </Link>
-          </div>
-
-          <div>
-            <Link to="/shows/90">
-              <RectImage src="/img/sotm_january_2017.png" aspectRatio={5}><div className="overlay" /></RectImage>
-            </Link>
-          </div>
-
+          {banners}
         </Slider>
       </div>
     );

--- a/react/frontpage/components/PromoBanner.scss
+++ b/react/frontpage/components/PromoBanner.scss
@@ -3,7 +3,6 @@
 
 .promoBanner {
   margin-bottom: 20pt;
-  cursor: pointer;
 }
 
 .promoBanner .overlay {
@@ -12,8 +11,10 @@
   top: 0;
   left: 0;
   position: absolute;
-}
+  cursor: pointer;
+  z-index: 1; // So overlay is on top of all other promo banner divs (need this to trigger :hover) 
 
-.promoBanner:hover .overlay {
-  background-color: $link-image-active-color;
+  &:hover {
+    background-color: $link-image-active-color;
+  }
 }

--- a/react/frontpage/components/PromoBanner.scss
+++ b/react/frontpage/components/PromoBanner.scss
@@ -1,0 +1,19 @@
+// Banner
+@import '../common';
+
+.promoBanner {
+  margin-bottom: 20pt;
+  cursor: pointer;
+}
+
+.promoBanner .overlay {
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  position: absolute;
+}
+
+.promoBanner:hover .overlay {
+  background-color: $link-image-active-color;
+}

--- a/react/frontpage/frontpage.scss
+++ b/react/frontpage/frontpage.scss
@@ -53,23 +53,3 @@ h4 {
   margin: 2*$box-padding 0;
   padding: 0 10pt;
 }
-
-// Banner
-
-.promoBanner {
-  background-color: white;
-  margin-bottom: 10pt;
-  cursor: pointer;
-}
-
-.promoBanner .overlay {
-  width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
-  position: absolute;
-}
-
-.promoBanner:hover .overlay {
-  background-color: $link-image-active-color;
-}


### PR DESCRIPTION
Fixes #74 
* Uses [react-slick](https://github.com/akiran/react-slick) for the carousel 

* Currently the images are hard coded in the new `PromoBanner.jsx` component, I might update this so the data is set in a JSON array so it's cleaner

Update: Commit [91b703a](https://github.com/uclaradio/uclaradio/pull/77/commits/91b703a09b7d1252293b5525874c51dc011790e8) addresses above

![screen shot 2017-03-13 at 12 30 25 am](https://cloud.githubusercontent.com/assets/9737156/23845356/c62381c0-0784-11e7-9814-f40b38146485.png)
![screen shot 2017-03-13 at 12 30 31 am](https://cloud.githubusercontent.com/assets/9737156/23845363/cdade778-0784-11e7-9b63-2992cd24969b.png)


