### PR TITLE
Fix express session warnings

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,6 +38,8 @@ app.use(cookieParser());
 app.use(session({
   key: "mysite.sid.uid.whatever",
   secret: "faeb4453e5d14fe6f6d04637f78077c76c73d1b4",
+  resave: false,
+  saveUninitialized: true,
   cookie: {
     maxAge: 2678400000 // 31 days
   },


### PR DESCRIPTION
Fixes some warnings which we see in the node console, relating to `express-session`:

<img width="571" alt="screen shot 2017-03-14 at 3 47 34 pm" src="https://cloud.githubusercontent.com/assets/2042745/23973721/9e030b7c-0994-11e7-91b6-c59fcf64cbad.png">