### PR TITLE
Grid-view Bug Fixes

### DIFF
--- a/react/frontpage/_common.scss
+++ b/react/frontpage/_common.scss
@@ -15,6 +15,11 @@ $link-hover-color: rgba(white, 0.9);
 $link-image-hover-color: rgba(white, 0.6);
 $link-image-active-color: rgba(white, 0.35);
 
+$mixcloud: #273a4b;
+$soundcloud: #ff8800;
+$tumblr: #35465c;
+$facebook: #3b5998;
+
 /** Animations **/
 
 @mixin fade($start-opacity, $end-opacity) {
@@ -55,3 +60,30 @@ $link-image-active-color: rgba(white, 0.35);
   -o-animation: $animationName $duration; /* Opera < 12.1 */
   animation: $animationName $duration;
 }
+
+// social media link styling
+
+.fa {
+  margin-right: 7pt;
+}
+
+.facebookLogo:hover {
+  color: $facebook !important;
+  opacity: 0.95;
+}
+
+.tumblrLogo:hover {
+  color: $tumblr !important;
+  opacity: 0.95;
+}
+
+.soundcloudLogo:hover {
+  color: $soundcloud !important;
+  opacity: 0.95;
+}
+
+.mixcloudLogo:hover {
+  color: $mixcloud !important;
+  opacity: 0.95;
+}
+

--- a/react/frontpage/components/ShowBlurb.jsx
+++ b/react/frontpage/components/ShowBlurb.jsx
@@ -56,19 +56,24 @@ var ShowBlurb = React.createClass({
         
         <div className="dot" style={{backgroundColor: 'rgba(255,0,0,0.45)', left: 1, marginRight: 10}}></div>
         <h1 className="header" style={{position: "relative", display: "inline-block"}}>SELECTED SHOW: </h1>
-        <Link to={this.urlFromShow(this.props.show)}>
-          <div className="blurb">
-            <div style={{ padding: '5px', marginLeft: '5px', marginRight: '5px' }}>
-              <h1 className="showTitle">{this.props.show.title}</h1>
-              <RectImage maxWidth="350px" src={this.props.show.picture || defaultShowPic} />
-              <p className="djs">{this.djString(this.props.show.djs || {})}</p>
-              <div className="lineStyle"/>
-              <div className="lineStyle"/>
-              <p className="time">{this.props.show.day.toUpperCase()} @ {this.props.show.time.toUpperCase()}<span style={{float: "right"}}>{this.props.show.genre}</span></p>
-              <p className="blurbText">{this.props.show.blurb}</p>
+        <div className="blurb">
+          <div style={{ padding: '5px', marginLeft: '5px', marginRight: '5px' }}>
+            <h1 className="showTitle">{this.props.show.title}</h1>
+            <RectImage maxWidth="350px" src={this.props.show.picture || defaultShowPic} />
+            <p className="djs">{this.djString(this.props.show.djs || {})}</p>
+            <div className="lineStyle"/>
+            <div className="lineStyle"/>
+            <p className="time">{this.props.show.day.toUpperCase()} @ {this.props.show.time.toUpperCase()}<span style={{float: "right"}}>{this.props.show.genre}</span></p>
+            <div className='social-icons'>
+              {this.props.show.facebook && <a className='facebookLogo' href={this.props.show.facebook} target='_blank'><i className='fa fa-facebook-square fa-lg' aria-hidden='true'></i></a>}
+              {this.props.show.tumblr && <a className='tumblrLogo' href={this.props.show.tumblr} target='_blank'><i className='fa fa-tumblr-square fa-lg' aria-hidden='true'></i></a>}
+              {this.props.show.soundcloud && <a className='soundcloudLogo' href={this.props.show.soundcloud} target='_blank'><i className='fa fa-soundcloud fa-lg' aria-hidden='true'></i></a>}
+              {this.props.show.mixcloud && <a className='mixcloudLogo' href={this.props.show.mixcloud} target='_blank'><i className='fa fa-mixcloud fa-lg' aria-hidden='true'></i></a>}
             </div>
-          </div> 
-        </Link>
+            <p className="blurbText">{this.props.show.blurb}</p>
+            <Link to={this.urlFromShow(this.props.show)}>[CLICK FOR FULL SHOW PAGE]</Link>
+          </div>
+        </div> 
       </div>
     );
   

--- a/react/frontpage/components/ShowBlurb.jsx
+++ b/react/frontpage/components/ShowBlurb.jsx
@@ -54,12 +54,14 @@ var ShowBlurb = React.createClass({
     return (
       <div className="showBlurb">
         
-        <div className="dot" style={{backgroundColor: 'rgba(255,0,0,0.45)', left: 1, marginRight: 10}}></div>
-        <h1 className="header" style={{position: "relative", display: "inline-block"}}>SELECTED SHOW: </h1>
+        <div className="dot"></div>
+        <h1 className="header">SELECTED SHOW: </h1>
         <div className="blurb">
-          <div style={{ padding: '5px', marginLeft: '5px', marginRight: '5px' }}>
+          <div className="blurb-body">
             <h1 className="showTitle">{this.props.show.title}</h1>
-            <RectImage maxWidth="350px" src={this.props.show.picture || defaultShowPic} />
+            <Link to={this.urlFromShow(this.props.show)}>
+              <RectImage maxWidth="350px" src={this.props.show.picture || defaultShowPic} />
+            </Link>
             <p className="djs">{this.djString(this.props.show.djs || {})}</p>
             <div className="lineStyle"/>
             <div className="lineStyle"/>

--- a/react/frontpage/components/ShowBlurb.jsx
+++ b/react/frontpage/components/ShowBlurb.jsx
@@ -9,6 +9,7 @@ import { Link } from 'react-router';
 
 // styling
 require('./ShowBlurb.scss');
+require('../_common.scss');
 
 const defaultShowPic = "/img/radio.png";
 

--- a/react/frontpage/components/ShowBlurb.scss
+++ b/react/frontpage/components/ShowBlurb.scss
@@ -4,12 +4,6 @@ ShowsBlurb.scss
 Sass styling for show blurb on shows page (with grid)
 **/
 
-$mixcloud: #273a4b;
-$soundcloud: #ff8800;
-$tumblr: #35465c;
-$facebook: #3b5998;
-
-
 .header {
   font-size: 15px;
   font-weight: lighter;
@@ -74,28 +68,4 @@ $facebook: #3b5998;
   margin-right: 10px;
   position: relative;
   left: 1;
-}
-
-.fa {
-  margin-right: 7pt;
-}
-
-.facebookLogo:hover {
-  color: $facebook !important;
-  opacity: 0.95;
-}
-
-.tumblrLogo:hover {
-  color: $tumblr !important;
-  opacity: 0.95;
-}
-
-.soundcloudLogo:hover {
-  color: $soundcloud !important;
-  opacity: 0.95;
-}
-
-.mixcloudLogo:hover {
-  color: $mixcloud !important;
-  opacity: 0.95;
 }

--- a/react/frontpage/components/ShowBlurb.scss
+++ b/react/frontpage/components/ShowBlurb.scss
@@ -13,6 +13,8 @@ $facebook: #3b5998;
 .header {
   font-size: 15px;
   font-weight: lighter;
+  position: relative; 
+  display: inline-block;
 }
 
 .blurbStyle {
@@ -40,6 +42,12 @@ $facebook: #3b5998;
   position: relative;
 }
 
+.blurb-body {
+  padding: 5px; 
+  margin-left: 5px;
+  margin-right: 5px;
+}
+
 .showTitle {
   font-size: 20px;
   font-weight: lighter;
@@ -57,13 +65,15 @@ $facebook: #3b5998;
 }
 
 .dot {
-  background-color: grey;
+  background-color: rgba(255,0,0,0.45);
   width: 10px;
   height: 10px;
   border-radius: 50%;
   display: inline-block;
   margin-left: 5px;
+  margin-right: 10px;
   position: relative;
+  left: 1;
 }
 
 .fa {

--- a/react/frontpage/components/ShowBlurb.scss
+++ b/react/frontpage/components/ShowBlurb.scss
@@ -4,6 +4,12 @@ ShowsBlurb.scss
 Sass styling for show blurb on shows page (with grid)
 **/
 
+$mixcloud: #273a4b;
+$soundcloud: #ff8800;
+$tumblr: #35465c;
+$facebook: #3b5998;
+
+
 .header {
   font-size: 15px;
   font-weight: lighter;
@@ -47,6 +53,7 @@ Sass styling for show blurb on shows page (with grid)
 .blurbText {
   font-size: 12px;
   font-weight: lighter;
+  margin-top: 10px;
 }
 
 .dot {
@@ -57,4 +64,28 @@ Sass styling for show blurb on shows page (with grid)
   display: inline-block;
   margin-left: 5px;
   position: relative;
+}
+
+.fa {
+  margin-right: 7pt;
+}
+
+.facebookLogo:hover {
+  color: $facebook !important;
+  opacity: 0.95;
+}
+
+.tumblrLogo:hover {
+  color: $tumblr !important;
+  opacity: 0.95;
+}
+
+.soundcloudLogo:hover {
+  color: $soundcloud !important;
+  opacity: 0.95;
+}
+
+.mixcloudLogo:hover {
+  color: $mixcloud !important;
+  opacity: 0.95;
 }

--- a/react/frontpage/components/ShowList.jsx
+++ b/react/frontpage/components/ShowList.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { Link } from 'react-router';
 
 require('./ShowList.scss');
+require('../_common.scss');
 
 // order in which days appear
 const scheduleDays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];

--- a/react/frontpage/components/ShowPage.scss
+++ b/react/frontpage/components/ShowPage.scss
@@ -4,11 +4,6 @@ ShowPage.scss
 Sass styling for individual show's page in new frontpage
 **/
 
-$mixcloud: #273a4b;
-$soundcloud: #ff8800;
-$tumblr: #35465c;
-$facebook: #3b5998;
-
 .showPage {
   margin: 10pt 0;
   padding: 10pt 20pt;
@@ -26,28 +21,4 @@ $image-width: 30%;
   display: inline-block;
   width: 100% - $image-width;
   padding: 10pt 20pt;
-}
-
-.fa {
-  margin-right: 7pt;
-}
-
-.facebookLogo:hover {
-  color: $facebook !important;
-  opacity: 0.95;
-}
-
-.tumblrLogo:hover {
-  color: $tumblr !important;
-  opacity: 0.95;
-}
-
-.soundcloudLogo:hover {
-  color: $soundcloud !important;
-  opacity: 0.95;
-}
-
-.mixcloudLogo:hover {
-  color: $mixcloud !important;
-  opacity: 0.95;
 }

--- a/react/frontpage/components/ShowsGraph.jsx
+++ b/react/frontpage/components/ShowsGraph.jsx
@@ -40,9 +40,9 @@ const ShowsGraph = React.createClass({
     });
   },
   
-  findStartTime: function() { // find earliest show time
+  findStartTime: function() { // find earliest show time (after 5am)
     var found = 0;
-    for(var s = 1; s < Dates.availableTimes.length; s++){
+    for(var s = 5; s < Dates.availableTimes.length; s++){
       for(var showIndex = 0; showIndex < this.props.shows.length; showIndex++){
         if(this.props.shows[showIndex].time == Dates.availableTimes[s]){
           found = 1;
@@ -56,6 +56,20 @@ const ShowsGraph = React.createClass({
 
   findEndTime: function() {  // find latest show time
     var found = 0;
+
+    // check late night (after midnight and before 5am) shows first
+    for(var e = 4; e >= 0; e--){
+      for(var showIndex = 0; showIndex < this.props.shows.length; showIndex++){
+        if(this.props.shows[showIndex].time == Dates.availableTimes[e]){
+          found = 1;
+          break;
+        }
+      }
+      if(found) {break;}
+    }
+    if (found) { return e;}
+
+    // now check before midnight
     for(var e = Dates.availableTimes.length-1; e > 0; e--){
       for(var showIndex = 0; showIndex < this.props.shows.length; showIndex++){
         if(this.props.shows[showIndex].time == Dates.availableTimes[e]){
@@ -84,7 +98,11 @@ const ShowsGraph = React.createClass({
     var start = this.findStartTime();
     var end = this.findEndTime(); 
 
-    for (var hour = start; hour < end+1; hour++) {
+    var hour = start;
+
+    var endMargin = end < 5 ? Dates.availableTimes.length-1 : end;
+
+    for (; hour < endMargin+1; hour++) {
       var hourString = Dates.availableTimes[hour];
       showBlocks.push( 
         <div className="hourBlocks">
@@ -102,6 +120,54 @@ const ShowsGraph = React.createClass({
         </div>
       );
     }
+
+    if (end < 5) {
+      for (hour = 0; hour < end+1; hour++) {
+        var hourString = Dates.availableTimes[hour];
+        showBlocks.push( 
+          <div className="hourBlocks">
+            <p className="timeStyle" style={{width: dayWidth}}>{hourString}</p>
+            { week.map((day) => {
+              var displayDay;
+
+              switch (day) {
+                case "sunday":
+                  displayDay = "monday";
+                  break;
+                case "monday":
+                  displayDay = "tuesday";
+                  break;
+                case "tuesday":
+                  displayDay = "wednesday";
+                  break;
+                case "wednesday":
+                  displayDay = "thursday";
+                  break;
+                case "thursday":
+                  displayDay = "friday";
+                  break;
+                case "friday":
+                  displayDay = "saturday";
+                  break;
+                case "saturday":
+                  displayDay = "sunday";
+                  break;
+              }
+
+              var show = this.state.schedule && this.state.schedule[displayDay][hour];
+              return (
+                <ShowBlock isValidShow={(show && show.title)}
+                  isCurrentShow={show && show.id === this.props.currentShowID}
+                  isActiveShow={show && show.id === this.props.activeShowID}
+                  isSpotlightShow={show && show.id === this.props.spotlightShowID}
+                  handleClick={()=>{show && this.props.onShowClick(show)}} />
+              );
+            })}
+          </div>
+        );
+      }
+
+    } 
 
     return (
       <div className="showsGraph">
@@ -182,7 +248,7 @@ const sortedShows = (shows) => {
     var show = shows[s];
     var day = Dates.dayFromVar(show.day).toLowerCase();
     var hour = Dates.availableTimes.indexOf(show.time);
-    if (day && hour) {
+    if (day) {
       schedule[day][hour] = show;
     }
   }

--- a/react/frontpage/components/ShowsGraph.jsx
+++ b/react/frontpage/components/ShowsGraph.jsx
@@ -82,6 +82,35 @@ const ShowsGraph = React.createClass({
     return e;
   },
 
+  lateNightDay: function(day) {
+    var displayDay;
+
+    switch (day) {
+      case "sunday":
+        displayDay = "monday";
+        break;
+      case "monday":
+        displayDay = "tuesday";
+        break;
+      case "tuesday":
+        displayDay = "wednesday";
+        break;
+      case "wednesday":
+        displayDay = "thursday";
+        break;
+      case "thursday":
+        displayDay = "friday";
+        break;
+      case "friday":
+        displayDay = "saturday";
+        break;
+      case "saturday":
+        displayDay = "sunday";
+        break;
+    }
+    return displayDay;
+  },
+
   render: function() {
 
     var dayTitles = week.map((day) => {
@@ -121,39 +150,14 @@ const ShowsGraph = React.createClass({
       );
     }
 
-    if (end < 5) {
+    if (end < 5) { // if we have late-night shows to display
       for (hour = 0; hour < end+1; hour++) {
         var hourString = Dates.availableTimes[hour];
         showBlocks.push( 
           <div className="hourBlocks">
             <p className="timeStyle" style={{width: dayWidth}}>{hourString}</p>
             { week.map((day) => {
-              var displayDay;
-
-              switch (day) {
-                case "sunday":
-                  displayDay = "monday";
-                  break;
-                case "monday":
-                  displayDay = "tuesday";
-                  break;
-                case "tuesday":
-                  displayDay = "wednesday";
-                  break;
-                case "wednesday":
-                  displayDay = "thursday";
-                  break;
-                case "thursday":
-                  displayDay = "friday";
-                  break;
-                case "friday":
-                  displayDay = "saturday";
-                  break;
-                case "saturday":
-                  displayDay = "sunday";
-                  break;
-              }
-
+              var displayDay = this.lateNightDay(day);
               var show = this.state.schedule && this.state.schedule[displayDay][hour];
               return (
                 <ShowBlock isValidShow={(show && show.title)}


### PR DESCRIPTION
1. Added support for late-night shows. Previously, 12am shows weren't showing up at all on the schedule, and early morning shows would potentially leave a big gap in the schedule. For example, 12am-4am shows on Tuesday morning would be placed in the Tuesday column, and allow for a big gap in the grid between that and the next 8am show. 
I fixed the 12am bug, and made it so that shows at 12am-4am will display after 11pm on the previous night, for the sake of the grid's presentation.

2. Added social links to the show blurb on grid view. Also, removed the ability to click anywhere on the entire blurb to link to the full show page, and, instead, added an explicit clickable link at the bottom.

<img width="854" alt="screen shot 2017-04-16 at 5 56 24 pm" src="https://cloud.githubusercontent.com/assets/10100525/25075671/0c0b19fa-22ce-11e7-8581-56488e6bd1d3.png">

