### PR TITLE
Remove panel link from front page

### DIFF
--- a/react/frontpage/components/FrontPageNavbar.jsx
+++ b/react/frontpage/components/FrontPageNavbar.jsx
@@ -27,7 +27,7 @@ var FrontPageNavbar = React.createClass({
         browserHistory.push('/streamIssues');
         break;
       case 3:
-        window.open("http://apply.dailybruin.com/applications/ucla-radio/", "_blank");
+        window.open("http://apply.uclastudentmedia.com/applications/ucla-radio/", "_blank");
         break;
       case 4:
         browserHistory.push('/about');

--- a/react/frontpage/components/FrontPageNavbar.jsx
+++ b/react/frontpage/components/FrontPageNavbar.jsx
@@ -32,9 +32,6 @@ var FrontPageNavbar = React.createClass({
       case 4:
         browserHistory.push('/about');
         break;
-      case 5:
-        window.open("/panel", "_blank");
-        break;
       case 10:
         this.setState({open: !this.state.open});
         break;
@@ -87,8 +84,7 @@ var FrontPageNavbar = React.createClass({
               </NavItem>
             </LinkContainer>
             <NavItem eventKey={1} className="frontPageNavbarItem collapsed">Blog</NavItem>
-            <NavItem eventKey={3} className="frontPageNavbarItem collapsed">Apply</NavItem>
-            <NavItem eventKey={5} className="frontPageNavbarItem rightMost collapsed">Staff Panel</NavItem>
+            <NavItem eventKey={3} className="frontPageNavbarItem rightMost collapsed">Apply</NavItem>
           </Nav>
         </Collapse>
 
@@ -108,7 +104,6 @@ var FrontPageNavbar = React.createClass({
             <MenuItem className="dropdownNavbarItem" onClick={()=>{this.handleClick(2)}}>Stream Issues</MenuItem>
             <MenuItem className="dropdownNavbarItem" onClick={()=>{this.handleClick(1)}}>Blog</MenuItem>
             <MenuItem className="dropdownNavbarItem" onClick={()=>{this.handleClick(3)}}>Apply</MenuItem>
-            <MenuItem className="dropdownNavbarItem" onClick={()=>{this.handleClick(5)}}>Staff Panel</MenuItem>
           </NavDropdown>
         </Nav>
       </div>

--- a/react/frontpage/components/FrontPageNavbar.jsx
+++ b/react/frontpage/components/FrontPageNavbar.jsx
@@ -75,16 +75,28 @@ var FrontPageNavbar = React.createClass({
           <Nav justified bsStyle="pills" onSelect={this.handleClick}>
             <LinkContainer to="/about">
               <NavItem className="frontPageNavbarItem leftMost collapsed">
-                About
+                <span className="equalWidth">
+                  About
+                </span>
               </NavItem>
             </LinkContainer>
             <LinkContainer to="/streamIssues">
               <NavItem className="frontPageNavbarItem collapsed">
-                Stream Issues
+                <span className="equalWidth">
+                  Stream
+                </span>
               </NavItem>
             </LinkContainer>
-            <NavItem eventKey={1} className="frontPageNavbarItem collapsed">Blog</NavItem>
-            <NavItem eventKey={3} className="frontPageNavbarItem rightMost collapsed">Apply</NavItem>
+            <NavItem eventKey={1} className="frontPageNavbarItem collapsed">
+              <span className="equalWidth">
+                Blog
+              </span>
+            </NavItem>
+            <NavItem eventKey={3} className="frontPageNavbarItem rightMost collapsed">
+              <span className="equalWidth">
+                Apply
+              </span>
+            </NavItem>
           </Nav>
         </Collapse>
 


### PR DESCRIPTION
No one really goes to [panel](https://uclaradio.com/panel/) from [uclaradio.com](uclaradio.com) except sometimes weird non-radio people requesting accounts, so I figured it'd be better if we just removed it.

![screen shot 2017-07-09 at 7 24 04 am](https://user-images.githubusercontent.com/5677971/27994750-64c74b54-6478-11e7-8f8b-d1737b2de52a.png)

Look at how clean it looks!

I also updated the apply link from `http://apply.dailybruin.com/applications/ucla-radio/` to `http://apply.uclastudentmedia.com/applications/ucla-radio/`. The former redirects to the latter, but DB's no longer hosting the apply site, and knowing the assistant editor over there, he's bound to break things at some point lol.

__Note__: the css is a little messy here and I didn't want to get too deep into it, so I had to rename "Stream Issues" to "Stream" because "Stream Issues" is pretty long and giving me issues. I feel like this is a little less intuitive though so if anyone could suggest perhaps a more meaningful (and still short) title or make a CSS fix I'd love ya forever ❤️