### PR TITLE
No spread operator

### DIFF
--- a/app/routes/managers.js
+++ b/app/routes/managers.js
@@ -8,10 +8,10 @@ const accounts = require('../database/accounts');
 
 router.get('/', (req, res) => {
   accounts.allManagers((err, managers) => {
-    const publicManagers = managers.filter(manager => manager.public);
+    managers = managers.filter(manager => manager.public);
 
     // sort alphabetically by name
-    publicManagers.sort((a, b) => {
+    managers.sort((a, b) => {
       const positionA = a.position.toUpperCase();
       const positionB = b.position.toUpperCase();
       if (positionA < positionB) {
@@ -22,7 +22,7 @@ router.get('/', (req, res) => {
       return 0;
     });
 
-    res.render('managers', { managers: { ...publicManagers } });
+    res.render('managers', managers);
   });
 });
 


### PR DESCRIPTION
<!--- Be sure to add a descriptive title above! -->

## Types of changes
<!--- What types of changes does your code introduce to UCLA Radio? Put an `x` in the boxes that apply. -->

- [x] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)

## Purpose
We're running Node 6.2.2 on the server which doesn't support the spread operator rip. This should be only a temporary patch until we update Node.